### PR TITLE
Display Avg. score and Admin score once submitted

### DIFF
--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -220,6 +220,7 @@ public class DocumentResource extends BaseResource {
             User user = userDao.getById(score.getUserId());
             if (score.getUserId() == principal.getId()) {
                 noScore = false;
+                document.add("currAdminScore", score.getScore());
                 document.add("currentUsername", user.getUsername());
             }
             scores.add(Json.createObjectBuilder()
@@ -230,7 +231,7 @@ public class DocumentResource extends BaseResource {
         if (count == 0) {
             document.add("average", "NA");
         } else {
-            document.add("average", String.valueOf(total * 1.0f / count));
+            document.add("average", String.valueOf(count * 1.0f / total));
         }
         document.add("scores", scores);
         document.add("noScore", noScore);

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.score.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.score.html
@@ -1,8 +1,21 @@
 <div ng-if="userInfo.base_functions.indexOf('ADMIN') != -1">
-    <p class="well-sm">{{ 'document.view.score.message' | translate }}</p>
-    <div id="scoreDiv"> Current score: {{document.score}} </div>
-    <div id="errorMsg"> </div>
 
+
+    <div ng-if="!document.noScore"> 
+        <span>The score you submitted for this document is: {{document.currAdminScore}}</span><br> 
+        <span>The average score for this document across all admins is: {{document.average}}</span>
+    </div>
+
+
+
+    <div ng-if="document.noScore"> 
+        <p class="well-sm">{{ 'document.view.score.message' | translate }}</p>
+    </div>
+
+
+
+    <!--<div id="scoreDiv"> Current score: {{document.score}} </div>-->
+    <div id="errorMsg"> </div>
 
     <div hidden id="documentId">{{document.id}}</div>
   <form #myForm="ngForm" id="form" (ngSubmit)="onSubmit()" ng-if="document.noScore" style="visibility: visible">


### PR DESCRIPTION
-once admin has submitted score for document, they can no longer edit their score and now the socres tab shows the score they submitted and the overall average score
-Fixed bugs in middle end involving average calculation and storing admins score